### PR TITLE
added missing "ignore" property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "angular-translate-loader-url",
   "version": "2.2.0",
   "main": "./angular-translate-loader-url.js",
+  "ignore": [],
   "dependencies": {
     "angular-translate": "~2.2.0"
   }


### PR DESCRIPTION
Resolves "bower invalid-meta  angular-translate is missing "ignore" entry in bower.json" warning
