### PR TITLE
Can now be installed via NPM and used with Browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Please file any issues and bugs in our main repository at [angular-translate/ang
 $ bower install angular-translate-loader-url
 ```
 
+### via NPM
+
+```bash
+$ npm install angular-translate-loader-url
+```
+
 ### via cdnjs
 
 Please have a look at https://cdnjs.com/libraries/angular-translate-loader-url for specific versions.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "angular-translate-loader-url",
+  "version": "2.7.0",
+  "description": "Creates a loading function for a typical dynamic url pattern: \"locale.php?lang=en_US\", \"locale.php?lang=de_DE\", \"locale.php?language=nl_NL\" etc. Prefixing the specified url, the current requested, language id will be applied with \"?{queryParameter}={key}\". Using this service, the response of these urls must be an object of key-value pairs.",
+  "main": "angular-translate-loader-url.js",
+  "repository": {
+    "type": "git",
+    "url": "https://mchambaud@github.com/mchambaud/bower-angular-translate-loader-url.git"
+  },
+  "keywords": [
+    "angular",
+    "angular-translate",
+    "angular-translate-loader-url"
+  ],
+  "author": "Pascal Precht",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mchambaud/bower-angular-translate-loader-url/issues"
+  },
+  "homepage": "https://github.com/mchambaud/bower-angular-translate-loader-url"
+}


### PR DESCRIPTION
Added PACKAGE.JSON to allow installing angular-translate-loader-url using NPM, enabling proper Browserification in the process.
